### PR TITLE
fix-Campaña error al editar fecha de inicio

### DIFF
--- a/src/main/java/com/xcrm/controller/web/CampaignController.java
+++ b/src/main/java/com/xcrm/controller/web/CampaignController.java
@@ -139,7 +139,7 @@ public String showEditForm(
 
         if (optionalCampaign.isEmpty()) {
             redirectAttributes.addFlashAttribute("error", "Campaña no encontrada");
-            return "redirect:/campaigns/administration";
+            return "redirect:/campaigns/edit/";
         }
 
         Campaign campaign = optionalCampaign.get();
@@ -150,6 +150,14 @@ public String showEditForm(
         }
 
         try {
+            // Validación de fechas
+            LocalDate inicio = LocalDate.parse(fechaInicio);
+            LocalDate fin = LocalDate.parse(fechaFin);
+            if (fin.isBefore(inicio)) {
+                redirectAttributes.addFlashAttribute("error", "La fecha de fin no puede ser anterior a la fecha de inicio.");
+                return "redirect:/campaigns/edit/" + id;
+            }
+
             campaign.setNombre(nombre);
             campaign.setDescripcion(descripcion);
             campaign.setFechaInicio(LocalDate.parse(fechaInicio));


### PR DESCRIPTION
Implementar mensaje visual de error al editar una campaña antes de su fecha de inicio por ejemplo no puedes crear una campaña que empiece el día 2 y su fecha de fin sea día 1 de ese mismo mes